### PR TITLE
add support for neste input names - Fixes #2

### DIFF
--- a/src/DynamicElement.js
+++ b/src/DynamicElement.js
@@ -43,7 +43,7 @@ class DynamicElement {
 
         let event = this.io.event ?? DynamicElement.defaultConfig.io.event;
 
-        this.htmlElement = dynamicForm.htmlElement.querySelectorAll(`[name=${config.name}]`);
+        this.htmlElement = dynamicForm.htmlElement.querySelectorAll(`[name="${config.name}"]`);
         this.name = this.htmlElement[0].name;
         if (this.htmlElement.length === 0) {
             throw new Error(`Element ${config.name} not found`);

--- a/src/DynamicForm.js
+++ b/src/DynamicForm.js
@@ -61,7 +61,7 @@ class DynamicForm {
 
         // Create fields instance
         formConfiguration.fields.forEach(fieldConfig => {
-            let queryResult = self.htmlElement.querySelectorAll(`[name=${fieldConfig.name}]`);
+            let queryResult = self.htmlElement.querySelectorAll(`[name="${fieldConfig.name}"]`);
             let type = null, instance = null;
 
             if (queryResult.length === 0) {


### PR DESCRIPTION
By adding quotes around the input name in the attribute selectors given to `querySelectorAll()`, we can add support for nested input names such as `'options[responsive][showOnMobile]'`.

See issue #2 for more information
